### PR TITLE
An implementation of a simplified Solar System nomenclature.

### DIFF
--- a/src/main/java/collections/universe/Asteroid.java
+++ b/src/main/java/collections/universe/Asteroid.java
@@ -1,0 +1,16 @@
+package collections.universe;
+
+public class Asteroid extends HeavenlyBody {
+    public Asteroid(String name, double orbitalPeriod) {
+        super(name, orbitalPeriod, BodyTypes.ASTEROID);
+    }
+
+    @Override
+    public boolean addSatellite(HeavenlyBody satellite) {
+        if (satellite.getBodyType().equals(BodyTypes.ASTEROID)) {
+            return super.addSatellite(satellite);
+        }
+        System.out.println(satellite.getBodyType() + " cannot be a satellite to " + this.getBodyType());
+        return false;
+    }
+}

--- a/src/main/java/collections/universe/Comet.java
+++ b/src/main/java/collections/universe/Comet.java
@@ -1,0 +1,18 @@
+package collections.universe;
+
+public class Comet extends HeavenlyBody {
+    public Comet(String name, double orbitalPeriod) {
+        super(name, orbitalPeriod, BodyTypes.COMET);
+    }
+
+    @Override
+    public BodyTypes getBodyType() {
+        return super.getBodyType();
+    }
+
+    @Override
+    public boolean addSatellite(HeavenlyBody satellite) {
+        System.out.println(this.getBodyType() + " cannot have a satellite.");
+        return false;
+    }
+}

--- a/src/main/java/collections/universe/HeavenlyBody.java
+++ b/src/main/java/collections/universe/HeavenlyBody.java
@@ -1,0 +1,66 @@
+package collections.universe;
+
+import java.util.HashSet;
+import java.util.Set;
+
+public abstract class HeavenlyBody {
+    private final String name;
+    private final double orbitalPeriod;
+    private final Set<HeavenlyBody> satellites;
+    private final BodyTypes bodyType;
+
+    public enum BodyTypes {
+        PLANET,
+        MOON,
+        COMET,
+        ASTEROID
+    }
+
+    public HeavenlyBody(String name, double orbitalPeriod, BodyTypes bodyType) {
+        this.name = name;
+        this.orbitalPeriod = orbitalPeriod;
+        this.satellites = new HashSet<>();
+        this.bodyType = bodyType;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public double getOrbitalPeriod() {
+        return orbitalPeriod;
+    }
+
+    public String getBodyInformation() {
+        return "Type: " + this.bodyType + ". Orbital period: " + this.orbitalPeriod + ". Name: " + this.name + ".";
+    }
+
+    public boolean addSatellite(HeavenlyBody satellite) {
+        return this.satellites.add(satellite);
+    }
+
+    public Set<HeavenlyBody> getSatellites() {
+        return new HashSet<>(this.satellites);
+    }
+
+
+    public BodyTypes getBodyType() {
+        return bodyType;
+    }
+
+    @Override
+    public final boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if ((obj instanceof HeavenlyBody && this.name.equals(((HeavenlyBody) obj).getName()))) {
+            return this.bodyType == ((HeavenlyBody) obj).getBodyType();
+        }
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        return this.name.hashCode() + this.bodyType.hashCode() + 11;
+    }
+}

--- a/src/main/java/collections/universe/Main.java
+++ b/src/main/java/collections/universe/Main.java
@@ -1,0 +1,120 @@
+package collections.universe;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+public class Main {
+    private static Map<String, HeavenlyBody> solarSystem = new HashMap<>();
+    private static Set<HeavenlyBody> bodies = new HashSet<>();
+
+    public static void main(String[] args) {
+        HeavenlyBody temp = new Planet("Mercury", 88);
+        solarSystem.put(temp.getName(), temp);
+        bodies.add(temp);
+
+        temp = new Planet("Venus", 225);
+        solarSystem.put(temp.getName(), temp);
+        bodies.add(temp);
+
+        temp = new Planet("Earth", 365);
+        solarSystem.put(temp.getName(), temp);
+        bodies.add(temp);
+
+        HeavenlyBody tempMoon = new Moon("Moon", 27);
+        solarSystem.put(tempMoon.getName(), tempMoon);
+        temp.addSatellite(tempMoon);
+
+        temp = new Planet("Mars", 687);
+        solarSystem.put(temp.getName(), temp);
+        bodies.add(temp);
+
+        tempMoon = new Moon("Deimos", 1.3);
+        solarSystem.put(tempMoon.getName(), tempMoon);
+        temp.addSatellite(tempMoon);
+
+        tempMoon = new Moon("Phobos", 0.3);
+        solarSystem.put(tempMoon.getName(), tempMoon);
+        temp.addSatellite(tempMoon);
+
+        temp = new Planet("Jupiter", 4332);
+        solarSystem.put(temp.getName(), temp);
+        bodies.add(temp);
+
+        tempMoon = new Moon("Io", 1.8);
+        solarSystem.put(tempMoon.getName(), tempMoon);
+        temp.addSatellite(tempMoon);
+
+        tempMoon = new Moon("Europa", 3.5);
+        solarSystem.put(tempMoon.getName(), tempMoon);
+        temp.addSatellite(tempMoon);
+
+        tempMoon = new Moon("Ganymede", 7.1);
+        solarSystem.put(tempMoon.getName(), tempMoon);
+        temp.addSatellite(tempMoon);
+
+        tempMoon = new Moon("Callisto", 16.7);
+        solarSystem.put(tempMoon.getName(), tempMoon);
+        temp.addSatellite(tempMoon);
+
+        temp = new Planet("Saturn", 10759);
+        solarSystem.put(temp.getName(), temp);
+        bodies.add(temp);
+
+        temp = new Planet("Uranus", 30660);
+        solarSystem.put(temp.getName(), temp);
+        bodies.add(temp);
+
+        temp = new Planet("Neptune", 165);
+        solarSystem.put(temp.getName(), temp);
+        bodies.add(temp);
+
+        temp = new Planet("Pluto", 248);
+        solarSystem.put(temp.getName(), temp);
+        bodies.add(temp);
+
+        temp = new Asteroid("951 Gaspra", 1197);
+        solarSystem.put(temp.getName(), temp);
+        bodies.add(temp);
+
+        temp = new Asteroid("433 Eros", 643);
+        solarSystem.put(temp.getName(), temp);
+        bodies.add(temp);
+
+        temp = new Asteroid("4 Vesta", 1325);
+        solarSystem.put(temp.getName(), temp);
+        bodies.add(temp);
+
+        temp = new Comet("C/1811 W1", 755);
+        solarSystem.put(temp.getName(), temp);
+        bodies.add(temp);
+
+        temp = new Comet("C/1882 R1-A", 669);
+        solarSystem.put(temp.getName(), temp);
+        bodies.add(temp);
+
+        HeavenlyBody pluto = new Comet("Pluto", 842);
+        bodies.add(pluto);
+
+        System.out.println("Heavenly bodies information in a particular system:");
+        for (Map.Entry<String, HeavenlyBody> system : solarSystem.entrySet()) {
+            System.out.println("\t" + system.getValue().getBodyInformation());
+        }
+
+        Set<HeavenlyBody> moons = new HashSet<>();
+        for (HeavenlyBody planet : Main.bodies) {
+            moons.addAll(planet.getSatellites());
+        }
+        System.out.println("All Moons");
+        for (HeavenlyBody moon : moons) {
+            System.out.println("\t" + moon.getName());
+        }
+
+        HeavenlyBody body = solarSystem.get("Mars");
+        System.out.println("Moons of " + body.getName());
+        for (HeavenlyBody moon : body.getSatellites()) {
+            System.out.println("\t" + moon.getName());
+        }
+    }
+}

--- a/src/main/java/collections/universe/Moon.java
+++ b/src/main/java/collections/universe/Moon.java
@@ -1,0 +1,18 @@
+package collections.universe;
+
+public class Moon extends HeavenlyBody {
+    public Moon(String name, double orbitalPeriod) {
+        super(name, orbitalPeriod, BodyTypes.MOON);
+    }
+
+    @Override
+    public BodyTypes getBodyType() {
+        return super.getBodyType();
+    }
+
+    @Override
+    public boolean addSatellite(HeavenlyBody satellite) {
+        System.out.println(this.getBodyType() + " cannot have a satellite.");
+        return false;
+    }
+}

--- a/src/main/java/collections/universe/Planet.java
+++ b/src/main/java/collections/universe/Planet.java
@@ -1,0 +1,16 @@
+package collections.universe;
+
+public class Planet extends HeavenlyBody {
+    public Planet(String name, double orbitalPeriod) {
+        super(name, orbitalPeriod, BodyTypes.PLANET);
+    }
+
+    @Override
+    public boolean addSatellite(HeavenlyBody satellite) {
+        if (satellite.getBodyType().equals(BodyTypes.MOON)) {
+            return super.addSatellite(satellite);
+        }
+        System.out.println(satellite.getBodyType() + " cannot be a satellite to " + this.getBodyType());
+        return false;
+    }
+}


### PR DESCRIPTION
HashMap stores all instantiated Heavenly Bodies objects, which are classified by type constants.
Also, it`s possible to add satellites to certain types of Heavenly Bodies, that are added to the HashSet collection, as well as receive information about the specified celestial body.